### PR TITLE
Allowing a cloudant url

### DIFF
--- a/cloudant.go
+++ b/cloudant.go
@@ -53,9 +53,13 @@ type Index struct {
 }
 
 // NewClient ...
-func NewClient(username string, password string) (*Client, error) {
+func NewClient(username string, password string, url string) (*Client, error) {
 	auth := couchdb.BasicAuth(username, password)
-	url := fmt.Sprintf("https://%s.cloudant.com", username)
+
+	if (url == "") {
+		url = fmt.Sprintf("https://%s.cloudant.com", username)
+	}
+
 	couchClient, err := couchdb.NewClient(url, nil)
 	couchClient.SetAuth(auth)
 	return &Client{Client: couchClient, username: username, password: password}, err

--- a/cloudant_test.go
+++ b/cloudant_test.go
@@ -12,6 +12,7 @@ import (
 
 var username = os.Getenv("CLOUDANT_USER_NAME")
 var password = os.Getenv("CLOUDANT_PASSWORD")
+var url = os.Getenv("CLOUDANT_URL")
 
 const testDBName = "test_db"
 
@@ -21,7 +22,7 @@ var testDB *DB
 func TestMain(m *testing.M) {
 	// Create the test client
 	var err error
-	if testClient, err = NewClient(username, password); err != nil {
+	if testClient, err = NewClient(username, password, url); err != nil {
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
The url pattern forces the format `https://%s.cloudant.com`. However, there can be cases, such as a secure gateway, where another format is used. An optional parameter will allow overriding while defaulting to the opinionated setting. The couchdb library already handles custom urls, so only a passthrough is required.